### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,13 +101,6 @@ repos:
         args: ["--show-error-codes", "--install-types", "--non-interactive"]
         additional_dependencies: ["pytest", "types-requests"]
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
 # yamllint disable rule:comments-indentation
   # Check for misspellings in documentation files
   # - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit