### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 8 1 * *"
 
+env:
+  DEFAULT-PYTHON: "3.11"
+
 jobs:
   update-dependencies:
     name: "Update dependencies"
@@ -27,9 +30,11 @@ jobs:
 
       - name: "Set up Python"
         uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.default-python }}
 
       - name: "Update Python dependencies"
-        uses: pdm-project/update-deps-action@v1
+        uses: pdm-project/update-deps-action@v1.9
         with:
           sign-off-commit: "true"
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: "Fetch current semantic tag"
         id: fetch-tags
         # yamllint disable-line rule:line-length
-        uses: os-climate/devops-reusable-workflows/.github/actions/latest-semantic-tag@main
+        uses: os-climate/osc-github-devops/.github/actions/latest-semantic-tag@main
 
       - name: "Update version from tags for production release"
         run: |

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -65,4 +65,4 @@ jobs:
           pdm list --graph
 
       - name: "Run: pip-audit"
-        uses: pypa/gh-action-pip-audit@v1.0.8
+        uses: pypa/gh-action-pip-audit@v1.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           ignore-from-file: [.gitignore],}"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
+    rev: v0.6.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -94,19 +94,12 @@ repos:
           then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.0"
+    rev: "v1.11.2"
     hooks:
       - id: mypy
         verbose: true
         args: ["--show-error-codes", "--install-types", "--non-interactive"]
         additional_dependencies: ["pytest", "types-requests"]
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
 
 # yamllint disable rule:comments-indentation
   # Check for misspellings in documentation files


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit