### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 8 1 * *"
 
+env:
+  DEFAULT-PYTHON: "3.11"
+
 jobs:
   update-dependencies:
     name: "Update dependencies"
@@ -27,9 +30,11 @@ jobs:
 
       - name: "Set up Python"
         uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.default-python }}
 
       - name: "Update Python dependencies"
-        uses: pdm-project/update-deps-action@v1
+        uses: pdm-project/update-deps-action@v1.9
         with:
           sign-off-commit: "true"
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,69 +1,55 @@
 ---
-name: "🐍📦 Old Production build and release"
+name: '🐍📦 Production build and release'
 
 # GitHub/PyPI trusted publisher documentation:
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 # yamllint disable-line rule:truthy
 on:
+  # workflow_dispatch:
   push:
     # Only invoked on release tag pushes
     tags:
-      - 'v*.*.*'
+      - v*.*.*
 
 env:
-  python-version: "3.10"
+  python-version: '3.10'
 
 ### BUILD ###
 
 jobs:
-
   build:
-    name: "🐍 Build packages"
-    # Only publish on tag pushes
-    if: startsWith(github.ref, 'refs/tags/')
+    name: '🐍 Build packages'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      # IMPORTANT: mandatory for Sigstore
       id-token: write
-
     steps:
       ### BUILDING ###
 
-      - name: "Checkout repository"
+      - name: 'Checkout repository'
         uses: actions/checkout@v4
 
-      - name: "Setup Python"
-        uses: actions/setup-python@v5
+      - name: 'Setup PDM for build commands'
+        uses: pdm-project/setup-pdm@v4.1
+
+      - name: 'Setup Python 3.10'
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ env.python-version }}
 
-      - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
-
-      - name: "Fetch current semantic tag"
-        id: fetch-tags
-        # yamllint disable-line rule:line-length
-        uses: os-climate/devops-reusable-workflows/.github/actions/latest-semantic-tag@main
-
-      - name: "Update version from tags for production release"
+      - name: 'Update version from tags for production release'
         run: |
-          echo "Github tag/versioning: ${{ github.ref_name }}"
-          if (grep 'dynamic = \[\"version\"\]' pyproject.toml > /dev/null); then
-            echo "Proceeding build with dynamic versioning"
-          else
-            echo "Using legacy script to bump release version"
-            scripts/release-versioning.sh
-          fi
+          echo "Github versioning: ${{ github.ref_name }}"
+          scripts/release-versioning.sh
 
-      - name: "Build with PDM backend"
+      - name: 'Build with PDM backend'
         run: |
           pdm build
 
       ### SIGNING ###
 
-      - name: "Sign packages with Sigstore"
-        # Use new action
+      - name: 'Sign packages with Sigstore'
         uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
@@ -79,7 +65,9 @@ jobs:
   ### PUBLISH GITHUB ###
 
   github:
-    name: "📦 Publish to GitHub"
+    name: '📦 Publish to GitHub'
+    # Only publish on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
     runs-on: ubuntu-latest
@@ -87,30 +75,31 @@ jobs:
       # IMPORTANT: mandatory to publish artefacts
       contents: write
     steps:
-      - name: "⬇ Download build artefacts"
+      - name: '⬇ Download build artefacts'
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.ref_name }}
           path: dist/
 
-      - name: "📦 Publish artefacts to GitHub"
-        # https://github.com/softprops/action-gh-release
-        uses: softprops/action-gh-release@v2
+      - name: '📦 Publish release to GitHub'
+        uses: ModeSevenIndustrialSolutions/action-automatic-releases@latest
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Valid inputs are:
+          # repo_token, automatic_release_tag, draft, prerelease, title, files
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}"
-          # body_path: ${{ github.workspace }}/CHANGELOG.rst
+          automatic_release_tag: ${{ github.ref_name }}
+          title: ${{ github.ref_name }}
           files: |
             dist/*.tar.gz
             dist/*.whl
-            dist/*.sigstore*
 
   ### PUBLISH PYPI TEST ###
 
   testpypi:
-    name: "📦 Test publishing to PyPI"
+    name: '📦 Publish to PyPi Test'
+    # Only publish on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
     runs-on: ubuntu-latest
@@ -120,20 +109,20 @@ jobs:
       # IMPORTANT: mandatory for trusted publishing
       id-token: write
     steps:
-      - name: "⬇ Download build artefacts"
+      - name: '⬇ Download build artefacts'
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.ref_name }}
           path: dist/
 
-      - name: "Remove files unsupported by PyPi"
+      - name: 'Remove files unsupported by PyPi'
         run: |
           if [ -f dist/buildvars.txt ]; then
             rm dist/buildvars.txt
           fi
-          rm dist/*.sigstore*
+          rm dist/*.sig*
 
-      - name: "Test publishing to PyPI"
+      - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -142,7 +131,9 @@ jobs:
   ### PUBLISH PYPI ###
 
   pypi:
-    name: "📦 Publish to PyPi"
+    name: '📦 Publish to PyPi'
+    # Only publish on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - testpypi
     runs-on: ubuntu-latest
@@ -152,23 +143,23 @@ jobs:
       # IMPORTANT: mandatory for trusted publishing
       id-token: write
     steps:
-      - name: "⬇ Download build artefacts"
+      - name: '⬇ Download build artefacts'
         uses: actions/download-artifact@v4
         with:
           name: ${{ github.ref_name }}
           path: dist/
 
-      - name: "Remove files unsupported by PyPi"
+      - name: 'Remove files unsupported by PyPi'
         run: |
           if [ -f dist/buildvars.txt ]; then
             rm dist/buildvars.txt
           fi
-          rm dist/*.sigstore*
+          rm dist/*.sig*
 
-      - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v4
+      - name: 'Setup PDM for build commands'
+        uses: pdm-project/setup-pdm@v3
 
-      - name: "Publish release to PyPI"
+      - name: 'Publish release to PyPI'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -65,4 +65,4 @@ jobs:
           pdm list --graph
 
       - name: "Run: pip-audit"
-        uses: pypa/gh-action-pip-audit@v1.0.8
+        uses: pypa/gh-action-pip-audit@v1.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           ignore-from-file: [.gitignore],}"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
+    rev: v0.6.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -94,19 +94,12 @@ repos:
           then /bin/mkdir .mypy_cache; fi; exit 0'
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.0"
+    rev: "v1.11.2"
     hooks:
       - id: mypy
         verbose: true
         args: ["--show-error-codes", "--install-types", "--non-interactive"]
         additional_dependencies: ["pytest", "types-requests"]
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
 
 # yamllint disable rule:comments-indentation
   # Check for misspellings in documentation files


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit